### PR TITLE
topaz: Rename libstdc++.vendor to libstdc++_vendor

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -116,7 +116,7 @@ PRODUCT_PACKAGES += \
     libcamera2ndk_vendor \
     libdng_sdk.vendor \
     libgui_vendor \
-    libstdc++.vendor \
+    libstdc++_vendor \
     vendor.qti.hardware.camera.device@1.0.vendor \
     vendor.qti.hardware.camera.postproc@1.0.vendor
 


### PR DESCRIPTION
In A14 libstdc++.vendor has been renamed to libstdc++_vendor

https://github.com/Evolution-X-Devices/device_xiaomi_msm8953-common/commit/c2640085fff6d95cb3179083c789a3fea7c40a9d