### PR TITLE
topaz: overlay: Place volume panel on the right by default

### DIFF
--- a/overlay-lineage/lineage-sdk/packages/LineageSettingsProvider/res/values/defaults.xml
+++ b/overlay-lineage/lineage-sdk/packages/LineageSettingsProvider/res/values/defaults.xml
@@ -7,6 +7,6 @@
 <resources>
 
     <!-- Default for LineageSettings.Secure.VOLUME_PANEL_ON_LEFT -->
-    <bool name="def_volume_panel_on_left">true</bool>
+    <bool name="def_volume_panel_on_left">false</bool>
 
 </resources>


### PR DESCRIPTION
The volume panel is placed on the left, but should be on the right. This is a fix for this bug.